### PR TITLE
Set origin value in `Access-Control-Allow-Origin` header based on request origin (with whitelist)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cabal-dev
 .cabal-sandbox/
 cabal.sandbox.config
 cabal.config
+*/.stack-work

--- a/spork-spock/Spork/Middleware.hs
+++ b/spork-spock/Spork/Middleware.hs
@@ -22,7 +22,7 @@ import System.Posix.Syslog
 import Data.Default
 import Control.Monad.Trans
 
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import Data.Text.Encoding (decodeUtf8)
 import qualified Data.Text as T
 import System.Log.FastLogger
@@ -50,16 +50,37 @@ type URL = String
 corsMiddleware :: URL -> Application -> Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
 corsMiddleware url app req k =
   if requestMethod req == methodOptions
-    then k $ responseLBS status200 (mkCorsHeaders url) ""
+    then k $ responseLBS status200 (mkCorsHeaders req) ""
     else app req k
 
-setCorsHeaders :: URL -> SpockAction a b c ()
+setCorsHeaders :: Request -> SpockAction a b c ()
 setCorsHeaders = mapM_ (uncurry setHeader) . mkCorsHeaders
 
-mkCorsHeaders :: (IsString a, IsString b) => URL -> [(a, b)]
-mkCorsHeaders url =
+type Origin = BS8.ByteString
+
+-- TODO pass this from config and check against it
+allowedOrigins :: [Origin]
+allowedOrigins = [ "http://???" ]
+
+-- https://www.w3.org/TR/cors/#access-control-allow-origin-response-header
+allOrigins :: Origin
+allOrigins = "*" -- does not works with cors requests with credentials
+
+nullOrigin :: Origin
+nullOrigin = "null"
+
+refToOrigin ::  Maybe BS8.ByteString -> Origin
+refToOrigin Nothing = nullOrigin
+refToOrigin (Just ref) = origin
+  where
+    chunks = BS8.split '/' ref -- http://tools.ietf.org/html/rfc6454#section-7.1
+    origin = if length chunks >= 3 then BS8.intercalate "/" (take 3 chunks)
+                                   else nullOrigin
+
+mkCorsHeaders :: (IsString a, IsString b) => Request -> [(a, b)]
+mkCorsHeaders req =
   let allowOrigin  = ( fromString "Access-Control-Allow-Origin"
-                     , fromString $ url
+                     , fromString . BS8.unpack . refToOrigin . requestHeaderReferer $ req
                      )
       allowHeaders = ( fromString "Access-Control-Allow-Headers"
                      , fromString "Origin, X-Requested-With, Content-Type, Accept, Authorization"
@@ -68,7 +89,7 @@ mkCorsHeaders url =
                      , fromString "GET, POST, PUT, OPTIONS, DELETE"
                      )
       allowCredentials = ( fromString "Access-Control-Allow-Credentials"
-                          , fromString "true"
+                         , fromString "true"
                          )
 
 

--- a/spork-spock/stack.yaml
+++ b/spork-spock/stack.yaml
@@ -1,0 +1,27 @@
+resolver: nightly-2015-12-14
+
+packages:
+- '.'
+- '../spork-lib'
+- location:
+    git: git@github.com:yesodweb/wai.git
+    commit: 3f4ca5838192e7f64a82954caa48c2e815897352
+  subdirs:
+    - wai
+    - wai-extra
+    - warp
+    - auto-update
+
+- location:
+    git: git@github.com:kazu-yamamoto/http2.git        # v1.4.5, needed for warp
+    commit: 6922317d55a786a58d17b87da997cdb2a11691fc
+
+# - '../spork-migrate'
+
+extra-deps:
+  - postgresql-simple-sop-0.2
+
+flags: {}
+
+
+extra-package-dbs: []

--- a/spork-spock/stack.yaml
+++ b/spork-spock/stack.yaml
@@ -3,20 +3,6 @@ resolver: nightly-2015-12-14
 packages:
 - '.'
 - '../spork-lib'
-- location:
-    git: git@github.com:yesodweb/wai.git
-    commit: 3f4ca5838192e7f64a82954caa48c2e815897352
-  subdirs:
-    - wai
-    - wai-extra
-    - warp
-    - auto-update
-
-- location:
-    git: git@github.com:kazu-yamamoto/http2.git        # v1.4.5, needed for warp
-    commit: 6922317d55a786a58d17b87da997cdb2a11691fc
-
-# - '../spork-migrate'
 
 extra-deps:
   - postgresql-simple-sop-0.2


### PR DESCRIPTION
The goal is to enable XHR with credentials over CORS. For this a server should specify a full origin in the `Access-Control-Allow-Origin` header. With `*` browsers will not send credentials (ie, cookies) with such a request. 

> An "origin" is a protocol+hostname+port of a page the xhr request has been made from. It is set by browsers and can't be modified by Javascript from that page (that is, it relies on browsers as trusted parties, which is not true for some attacker using `curl` - proper credentials (shared unique hash transferred in cookies, for example) check is required). 
> 
> With `Access-Control-Allow-Origin` a server specifies requests from which origins it will accept. So apart of setting the origin header, the server has to check the origin header of incoming requests against the same whitelist as when setting the header.
> 
> This is only a first phase of security checks, proper auth checks still required after all these origin things will succeed.

The patch sets value of this header equal to the origin of the request (`Origin` header in request). This is effectively equal to `*`, but with credentials always sent. It would be a right thing to do to check request's origins against some whitelist of origins allowed to access the API, to notify browsers that they are not welcomed if they send requests from bad origins. Proper credentials check is still required, of course.

It compiles, but not tested in running mode. 

Also, keep in mind that a signature of exported function `setCorsHeaders` has changed to take `Request` as a parameter instead of `Url`.
